### PR TITLE
Update send-email.rs - Fixed for Contact List with more that one

### DIFF
--- a/rust_dev_preview/examples/ses/src/bin/send-email.rs
+++ b/rust_dev_preview/examples/ses/src/bin/send-email.rs
@@ -55,12 +55,13 @@ async fn send_message(
 
     let contacts = resp.contacts().unwrap_or_default();
 
-    let cs: String = contacts
+    let cs: Vec<String> = contacts
         .iter()
-        .map(|i| format!("{},",i.email_address().unwrap_or_default()))
+        .map(|i| i.email_address().unwrap_or_default().to_string() )
         .collect();
 
-    let dest = Destination::builder().to_addresses(cs).build();
+    let mut dest: Destination = Destination::builder().build();
+    dest.to_addresses = Some(cs);
     let subject_content = Content::builder().data(subject).charset("UTF-8").build();
     let body_content = Content::builder().data(message).charset("UTF-8").build();
     let body = Body::builder().text(body_content).build();


### PR DESCRIPTION
Fixed.
cs is being generated as String, if the Contact list has more that one contact it will fail. eg: user@example.comuser2@example.com...
Causes Exception:
Error: BadRequestException(BadRequestException { message: Some("Illegal address"), meta: ErrorMetadata { code: Some("BadRequestException"), message: Some("Illegal address"), extras: Some({"aws_request_id": "da0bf20a-52b3-4acc-bb22-eec27cf68322"}) } })

cs is now a Vec<String> and is directly assigned to dest.to_addresses

<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

This pull request...

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
